### PR TITLE
fixed url filtering.

### DIFF
--- a/lib/api/model/item.dart
+++ b/lib/api/model/item.dart
@@ -101,10 +101,7 @@ class Item
         // Summary, the list only takes the String if the String is an url.
         imagesUrl: imagesUrl.takeWhile((value) {
           if (value is String) {
-            final uri = Uri.tryParse(value);
-            if (uri != null) {
-              return uri.isAbsolute;
-            }
+            return true;
           }
           return false;
         }).map<String>((e) => e).toList(),


### PR DESCRIPTION
after all considerations, full URL for firestore is actually not needed. So I throw all the checks if a string is a url or not.